### PR TITLE
Syntactic cleanup

### DIFF
--- a/GUI/AnalysisWindow.java
+++ b/GUI/AnalysisWindow.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class AnalysisWindow {
+    
+}

--- a/GUI/Calendar.java
+++ b/GUI/Calendar.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class Calendar {
+    
+}

--- a/GUI/DataWindow.java
+++ b/GUI/DataWindow.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class DataWindow {
+    
+}

--- a/GUI/DropdownBox.java
+++ b/GUI/DropdownBox.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class DropdownBox {
+    
+}

--- a/GUI/ErrorWindow.java
+++ b/GUI/ErrorWindow.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class ErrorWindow {
+    
+}

--- a/GUI/GraphWindow.java
+++ b/GUI/GraphWindow.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class GraphWindow {
+    
+}

--- a/GUI/SummaryWindow.java
+++ b/GUI/SummaryWindow.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class SummaryWindow {
+    
+}

--- a/GUI/TextBox.java
+++ b/GUI/TextBox.java
@@ -1,0 +1,5 @@
+package AbstractClasses.GUI;
+
+class TextBox {
+    
+}

--- a/Trade/Action.java
+++ b/Trade/Action.java
@@ -1,1 +1,3 @@
+package AbstractClasses.Trade;
+
 enum Action { NEW, CANCEL, CORRECT; }

--- a/Trade/Asset.java
+++ b/Trade/Asset.java
@@ -1,0 +1,5 @@
+package AbstractClasses.Trade;
+
+public class Asset {
+    
+}

--- a/Trade/AssetClass.java
+++ b/Trade/AssetClass.java
@@ -1,0 +1,3 @@
+package AbstractClasses.Trade;
+
+public enum AssetClass{ COMMODITIES, CREDITS, EQUITY, FOREX, RATES; }

--- a/Trade/Collateralization.java
+++ b/Trade/Collateralization.java
@@ -1,1 +1,3 @@
+package AbstractClasses.Trade;
+
 enum Collateralization { UC, PC, FC, OC, BLANK; }

--- a/Trade/PriceFormingContinuationData.java
+++ b/Trade/PriceFormingContinuationData.java
@@ -1,3 +1,5 @@
+package AbstractClasses.Trade;
+
 enum PriceFormingContinuationData {
   TERMINATION,
   TRADE;

--- a/Trade/SubAssetClass.java
+++ b/Trade/SubAssetClass.java
@@ -1,3 +1,5 @@
+package AbstractClasses.Trade;
+
 enum SubAssetClass {
   ENERGY,
   METALS;

--- a/Trade/Trade.java
+++ b/Trade/Trade.java
@@ -1,4 +1,9 @@
-abstract class Trade {
+package AbstractClasses.Trade;
+
+import java.util.Currency;
+import java.util.Date;
+
+public abstract class Trade {
 	
 	//TODO: not sure on how to represent some of these fields at the moment	
 
@@ -17,14 +22,14 @@ abstract class Trade {
 	Date endDate;
 	AssetClass assetClass;
 	SubAssetClass subAssetClass;
-	??? taxonomy; //We need to understand what is the structure of this, inside the .csv files
+	String taxonomy; //TODO We need to understand what is the structure of this, inside the .csv files
 	PriceFormingContinuationData priceFormingContinuationData;
 	String underlyingAsset1;
 	String underlyingAsset2;
 	String priceNotationType;
 	int priceNotation;
-	String notionalCurrency1;
-	String notionalCurrency2;
+	Currency notionalCurrency1;
+	Currency notionalCurrency2;
 	long roundedNotionalAmount1;
 	long roundedNotionalAmount2;
 	

--- a/Trade/UPI.java
+++ b/Trade/UPI.java
@@ -1,0 +1,7 @@
+package AbstractClasses.Trade;
+
+public class UPI {
+    
+    String name;
+    
+}

--- a/communicationlayer/CommunicationLayer.java
+++ b/communicationlayer/CommunicationLayer.java
@@ -1,15 +1,17 @@
+package AbstractClasses.CommunicationLayer;
+
 abstract class CommunicationLayer {
 	
 	// Creates a Search from the current values of fields in the GUI
-	Search createSearch(); 
+	abstract Search createSearch(); 
 	
 	// Sends a Search to the database	
-	void sendSearch();
+	abstract void sendSearch();
 
 	// Polls for a SearchResult from the database
-	SearchResult getResult();
+	abstract SearchResult getResult();
 
 	// Passes the SearchResult on to any listening components (GUI and
 	// data analyser)
-	void sendResult()
+	abstract void sendResult();
 }

--- a/communicationlayer/Search.java
+++ b/communicationlayer/Search.java
@@ -1,11 +1,20 @@
-abstract class Search {
+package AbstractClasses.CommunicationLayer;
+
+import AbstractClasses.Trade.Asset;
+import AbstractClasses.Trade.*;
+import java.util.Currency;
+import java.util.Date;
+
+public abstract class Search {
     
     AssetClass assetClass;
     Asset asset;
     int minPrice, maxPrice;
     Currency currency;
-    DateTime startTime, endTime;
+    Date startTime, endTime;
     UPI upi;
     
-    public Search(AssetClass ac, Asset a, int minP, int maxP, Currency c, DateTime st, DateTime et, UPI upi){};
+    public Search(AssetClass ac, Asset a, int minP, int maxP, Currency c, Date st, Date et, UPI upi){
+	throw new UnsupportedOperationException("This method has not yet been implemented.");
+    };
 }

--- a/communicationlayer/SearchResult.java
+++ b/communicationlayer/SearchResult.java
@@ -1,4 +1,9 @@
-abstract class SearchResult {
+package AbstractClasses.CommunicationLayer;
+
+import AbstractClasses.Trade.Trade;
+import java.util.List;
+
+public abstract class SearchResult {
 	
 	// A list containing all of the trades fitting the search query	
 	List<Trade> resultData;

--- a/dataanalysis/Anomaly.java
+++ b/dataanalysis/Anomaly.java
@@ -1,5 +1,11 @@
+package AbstractClasses.DataAnalysis;
+
+import AbstractClasses.Trade.AssetClass;
+import AbstractClasses.Trade.Trade;
+import java.util.Date;
+
 abstract class Anomaly {
     AssetClass asset;
     Trade anomaly;
-    DateTime startTime, endTime; //time period for which it is an anomaly
+    Date startTime, endTime; //time period for which it is an anomaly
 }

--- a/dataanalysis/DataAnalyser.java
+++ b/dataanalysis/DataAnalyser.java
@@ -1,5 +1,10 @@
+package AbstractClasses.DataAnalysis;
+
+import AbstractClasses.Trade.Trade;
+import java.util.List;
+
 abstract class DataAnalyser {
-    void sendAnalysis(); //Sends results of analysis to GUI
-    List<Anomaly> identifyAnomalies(List<Trade>);
-    List<TrendAlert> identifyTrends(List<Trade>);
+    abstract void sendAnalysis(); //Sends results of analysis to GUI
+    abstract List<Anomaly> identifyAnomalies(List<Trade> trade);
+    abstract List<TrendAlert> identifyTrends(List<Trade> trade);
 }

--- a/dataanalysis/TrendAlert.java
+++ b/dataanalysis/TrendAlert.java
@@ -1,3 +1,5 @@
+package AbstractClasses.DataAnalysis;
+
 abstract class TrendAlert {
 
 }

--- a/database/AssetClass.java
+++ b/database/AssetClass.java
@@ -1,1 +1,0 @@
-enum AssetClass{ COMMODITIES, CREDITS, EQUITY, FOREX, RATES; }

--- a/database/CSVTradeFile.java
+++ b/database/CSVTradeFile.java
@@ -1,6 +1,15 @@
+package AbstractClasses.Database;
+
+import AbstractClasses.Trade.Trade;
+import java.io.File;
+
 abstract class CSVTradeFile extends File{
     String[] columnHeaders;
 
-    public CSVTradeFile(File f);
-    Trade getTrade(int i);
+    public CSVTradeFile(File f, String path){
+	super(path);
+	throw new UnsupportedOperationException("This function has not yet been implemented.");
+	// you can't have abstract constructors
+    }
+    abstract Trade getTrade(int i);
 }

--- a/database/Database.java
+++ b/database/Database.java
@@ -1,8 +1,33 @@
+package AbstractClasses.Database;
+
+import AbstractClasses.Trade.Trade;
+import AbstractClasses.CommunicationLayer.Search;
+import AbstractClasses.CommunicationLayer.SearchResult;
+import AbstractClasses.Trade.UPI;
+import java.util.Date;
+
 abstract class Database{
-    private void addTrade(Trade trade);
-    void addTrades(CSVTradeFile csv);
-    SearchResult search(Search s);
-    Time getLastUpdateTime();
-    Search[] getSavedSearches();
-    UPI[] getMatchingUPI(String s);
+    abstract protected void addTrade(Trade trade);
+    abstract void addTrades(CSVTradeFile csv);
+    abstract SearchResult search(Search s);
+    
+    /**
+     * 
+     * @return The time the database was last updated
+     */
+    abstract Date getLastUpdateTime();
+    
+    
+    /**
+     * 
+     * @return A list of previously saved searches
+     */
+    abstract Search[] getSavedSearches();
+    
+    /**
+     * 
+     * @param s The string to search against
+     * @return A list of UPIs which have the parameter as a substring
+     */
+    abstract UPI[] getMatchingUPI(String s);
 }

--- a/gui/GUI.java
+++ b/gui/GUI.java
@@ -1,9 +1,13 @@
+package AbstractClasses.GUI;
+
 abstract class GUI {
-    GUI() //initialise all sections
-    SearchWindow;
-    ErrorWindow;
-    GraphWindow;
-    DataWindow;
-    AnalysisWindow;
-    SummaryWindow;
+    public GUI(){
+	throw new UnsupportedOperationException("This method has not yet been implemented.");
+    }
+    SearchWindow search;
+    ErrorWindow error;
+    GraphWindow graph;
+    DataWindow data;
+    AnalysisWindow analysis;
+    SummaryWindow summary;
 }

--- a/gui/SearchWindow.java
+++ b/gui/SearchWindow.java
@@ -1,3 +1,5 @@
+package AbstractClasses.GUI;
+
 abstract class searchWindow {
     DropdownBox selectAsset;
     TextBox selectUPI;

--- a/networklayer/NetworkLayer.java
+++ b/networklayer/NetworkLayer.java
@@ -1,6 +1,10 @@
+package AbstractClasses.NetworkLayer;
+
+import java.util.Date;
+
 abstract class NetworkLayer {
     Date lastUpdateDate;
     int lastSlice; //the ID of the last received slice today, counting from 1
-    void initialUpdate(); //called at startup and every day afterwards
-    void poll(); //called internally by a timer
+    abstract void initialUpdate(); //called at startup and every day afterwards
+    abstract void poll(); //called internally by a timer
 }


### PR DESCRIPTION
Added appropriate keywords, etc. to ensure that all classes are syntactically valid for Java. This allows us to check that all referenced classes have been thought about as an IDE will flag any classes that we didn't have.

Thus added appropriate classes.

Added basic packaging, but we will probably want to repackage to uk.ac.cam.cl.somethingorother at some point.

Split out a new trade package as that makes most sense.
